### PR TITLE
Omit build dependency on autosave

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pydevsup (1.1) unstable; urgency=low
+
+  * FIX: omit deps on autosave, iocstats
+
+ -- Daron Chabot <chabot@frib.msu.edu>  Fri, 12 May 2017 14:07:33 -0400
+
 pydevsup (1.0) unstable; urgency=medium
 
   * initial

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,6 @@ Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@gmail.com>
 Build-Depends: debhelper (>= 9), dh-python, epics-debhelper (>= 8.13~),
                epics-dev,
-               epics-synapps-dev | epics-autosave-dev,
-               epics-synapps-dev | epics-iocstats-dev,
                python-all-dev,  python-numpy,
                python3-all-dev, python3-numpy,
 Standards-Version: 3.9.6

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 
 # Don't want to enable conditional deps. by default
 # but do want to build then for packaging
-EXTRA=AUTOSAVE=/usr/lib/epics
+#EXTRA=AUTOSAVE=/usr/lib/epics
 
 export DH_VERBOSE=1
 


### PR DESCRIPTION
Addresses #1.

Maybe add a `Recommends: epics-autosave-dev, epics-iocstats-dev` to `epics-pydevsup-dev`?
What do you think, @mdavidsaver 

Attn: @dylan171