### PR TITLE
Fix build on macOS

### DIFF
--- a/devsupApp/src/pydevsup.h
+++ b/devsupApp/src/pydevsup.h
@@ -15,8 +15,6 @@
 
 #endif
 
-initHookState pyInitLastState;
-
 PyMODINIT_FUNC init_dbbase(void);
 
 void pyDBD_cleanup(void);

--- a/devsupApp/src/setup.c
+++ b/devsupApp/src/setup.c
@@ -24,6 +24,8 @@
 
 #include "pydevsup.h"
 
+initHookState pyInitLastState;
+
 typedef struct {
     const initHookState state;
     const char * const name;

--- a/logApp/src/Makefile
+++ b/logApp/src/Makefile
@@ -9,7 +9,7 @@ include $(TOP)/configure/CONFIG_PY
 #=============================
 # Build the IOC application
 
-LOADABLE_LIBRARY_HOST = _inotifyy
+LOADABLE_LIBRARY_HOST_Linux = _inotifyy
 
 _inotifyy_SRCS += inotify_wrap.c
 


### PR DESCRIPTION
This changeset consists of three changes:

The order of rules in configure/Makefile is changed. For some reason, this is needed in order for `configure/os/CONFIG_PY3.7.Common.darwin-x86` to be generated correctly.

The declaration of the `pyInitLastState` global variable is moved from `pydevsup.h` to `setup.c`. This is needed to avoid a "duplicate symbols" error when linking. As this variable is only used in `setup.c` anyway, there is no downside in moving its declaration there.

The log example application is now only built on Linux. As it depends on the inotify API, which is Linux-specific, it cannot be reasonably built on other platforms. As it is not needed for the pyDevSup to work, it is OK to built it without this application.