### PR TITLE
Python init: don't install sig handlers. Fix #5

### DIFF
--- a/pyIocApp/setup.c
+++ b/pyIocApp/setup.c
@@ -114,7 +114,7 @@ static void setupPyPath(void)
 
 static void pySetupReg(void)
 {
-    Py_Initialize();
+    Py_InitializeEx(0);
     PyEval_InitThreads();
 
     setupPyPath();


### PR DESCRIPTION
Py_InitializeEx(0)  tells the embedded interpreter to not install signal handlers. This fix is ignored by Python <3.7. See https://bugs.python.org/issue35233.