### PR TITLE
Try to ensure cleanupPy() is run early on shutdown.

### DIFF
--- a/pyIocApp/setup.c
+++ b/pyIocApp/setup.c
@@ -123,7 +123,7 @@ static void cleanupPrep(initHookState state)
     /* register a second time to better our chances of running
      * first on exit.  eg. before cacExitHandler()
      */
-    if(state==initHookAfterIocRunning)
+    if(state==initHookAfterInitDevSup)
         epicsAtExit(&cleanupPy, NULL);
 }
 


### PR DESCRIPTION
Add in registrar happens early in startup, and
will be run near the end of shutdown.
Even if iocInit() isn't run.

Also use an initHook to add cleanupPy(), which
happens late in startup, and will be run early
on shutdown.  Though only if iocInit() is run.