### PR TITLE
Included the following record types: calcout, int64in, int64out, lsi …

### DIFF
--- a/devsupApp/src/devsup/__init__.py
+++ b/devsupApp/src/devsup/__init__.py
@@ -75,6 +75,15 @@ device(mbboDirect, INST_IO, pydevsupComOut, "Python Device")
 device(waveform, INST_IO, pydevsupComIn, "Python Device")
 device(aai, INST_IO, pydevsupComIn, "Python Device")
 device(aao, INST_IO, pydevsupComOut, "Python Device")
+
+device(calcout, INST_IO, pydevsupComOut, "Python Device")
+
+device(int64in, INST_IO, pydevsupComIn, "Python Device")
+device(int64out, INST_IO, pydevsupComOut, "Python Device")
+
+device(lsi, INST_IO, pydevsupComIn, "Python Device")
+device(lso, INST_IO, pydevsupComOut, "Python Device")
+
 """.encode('ascii'))
         F.flush()
         _dbapi.dbReadDatabase(F.name)


### PR DESCRIPTION
…and lso.
Impacted file: devsupApp/src/devsup/__init__.py
All worked when I tested on my system: rocky 8 using base-7.0.7
