### PR TITLE
Replace `distutils` and `numpy.distutils`

### DIFF
--- a/makehelper.py
+++ b/makehelper.py
@@ -33,8 +33,9 @@ libdir = get_config_var('LIBDIR') or ''
 
 have_np='NO'
 try:
-    from numpy.distutils.misc_util import get_numpy_include_dirs
-    incdirs = get_numpy_include_dirs()+incdirs
+    from numpy import get_include
+    numpy_dir = [get_include()]
+    incdirs = numpy_dir+incdirs
     have_np='YES'
 except ImportError:
     pass

--- a/makehelper.py
+++ b/makehelper.py
@@ -26,9 +26,9 @@ else:
         pass
     out = open(sys.argv[1], 'w')
 
-from distutils.sysconfig import get_config_var, get_python_inc
+from sysconfig import get_config_var, get_path, get_python_version
 
-incdirs = [get_python_inc()]
+incdirs = [get_path("include")]
 libdir = get_config_var('LIBDIR') or ''
 
 have_np='NO'
@@ -42,10 +42,10 @@ except ImportError:
 print('TARGET_CFLAGS +=',get_config_var('BASECFLAGS'), file=out)
 print('TARGET_CXXFLAGS +=',get_config_var('BASECFLAGS'), file=out)
 
-print('PY_VER :=',get_config_var('VERSION'), file=out)
+print('PY_VER :=',get_python_version(), file=out)
 ldver = get_config_var('LDVERSION')
 if ldver is None:
-    ldver = get_config_var('VERSION')
+    ldver = get_python_version()
     if get_config_var('Py_DEBUG'):
         ldver = ldver+'_d'
 print('PY_LD_VER :=',ldver, file=out)


### PR DESCRIPTION
This PR resolves issues with `distutils`, which is deprecated/removed with Python 3.12 and `numpy.distutils` which is deprecated/removed with newer numpy versions.

This fixes #35 

I ran tests to compare the output for Python 3.8, Python 3.11 and Python 3.12. For Python 3.11 and Python 3.12 I also tested with `numpy` 1.26 and `numpy` 2.0

The output with the changes in this PR were consistent with previous output, but now also provides the correct information regarding the numpy include path for Python3.12/numpy1.26/numpy2.0

So far I have not tested this for Python versions smaller 3.8