### PR TITLE
[Enhancement] Support optional alarm message in `Record.setSevr()`

### DIFF
--- a/devsupApp/src/dbrec.c
+++ b/devsupApp/src/dbrec.c
@@ -125,10 +125,11 @@ static PyObject* pyRecord_setSevr(pyRecord *self, PyObject *args, PyObject *kws)
 {
     dbCommon *prec = self->entry.precnode->precord;
 
-    static char* names[] = {"sevr", "stat", NULL};
+    static char* names[] = {"sevr", "stat", "message", NULL};
     short sevr = INVALID_ALARM, stat=COMM_ALARM;
+    const char *message = NULL;
 
-    if(!PyArg_ParseTupleAndKeywords(args, kws, "|hh", names, &sevr, &stat))
+    if(!PyArg_ParseTupleAndKeywords(args, kws, "|hhz", names, &sevr, &stat, &message))
         return NULL;
 
     if(sevr<firstEpicsAlarmSev || sevr>lastEpicsAlarmSev
@@ -137,7 +138,13 @@ static PyObject* pyRecord_setSevr(pyRecord *self, PyObject *args, PyObject *kws)
         PyErr_Format(PyExc_ValueError, "%s: Can't set alarms %d %d", prec->name, sevr, stat);
         return NULL;
     }
-
+// @since 7.0.6
+#ifdef HAS_ALARM_MESSAGE
+    if(message) {
+        recGblSetSevrMsg(prec, stat, sevr, "%s", message);
+        Py_RETURN_NONE;
+    }
+#endif
     recGblSetSevr(prec, stat, sevr);
     Py_RETURN_NONE;
 }

--- a/devsupApp/src/dbrec.c
+++ b/devsupApp/src/dbrec.c
@@ -125,11 +125,11 @@ static PyObject* pyRecord_setSevr(pyRecord *self, PyObject *args, PyObject *kws)
 {
     dbCommon *prec = self->entry.precnode->precord;
 
-    static char* names[] = {"sevr", "stat", "message", NULL};
+    static char* names[] = {"sevr", "stat", "amsg", NULL};
     short sevr = INVALID_ALARM, stat=COMM_ALARM;
-    const char *message = NULL;
+    const char *amsg = NULL;
 
-    if(!PyArg_ParseTupleAndKeywords(args, kws, "|hhz", names, &sevr, &stat, &message))
+    if(!PyArg_ParseTupleAndKeywords(args, kws, "|hhz", names, &sevr, &stat, &amsg))
         return NULL;
 
     if(sevr<firstEpicsAlarmSev || sevr>lastEpicsAlarmSev
@@ -140,8 +140,8 @@ static PyObject* pyRecord_setSevr(pyRecord *self, PyObject *args, PyObject *kws)
     }
 // @since 7.0.6
 #ifdef HAS_ALARM_MESSAGE
-    if(message) {
-        recGblSetSevrMsg(prec, stat, sevr, "%s", message);
+    if(amsg) {
+        recGblSetSevrMsg(prec, stat, sevr, "%s", amsg);
         Py_RETURN_NONE;
     }
 #endif
@@ -324,8 +324,9 @@ static PyMethodDef pyRecord_methods[] = {
      "infos() -> {'name':'value'}\n"
      "Return a dictionary of all infos for this record."},
     {"setSevr", (PyCFunction)pyRecord_setSevr, METH_VARARGS|METH_KEYWORDS,
-     "setSevr(sevr=INVALID_ALARM, stat=COMM_ALARM)\n"
-     "Set alarm new alarm severity/status.  Record must be locked!"},
+     "setSevr(sevr=INVALID_ALARM, stat=COMM_ALARM, amsg=Nome)\n"
+     "Set alarm new alarm severity/status.  Record must be locked!\n"
+     "amsg requires EPICS Base >= 7.0.6."},
     {"setTime", (PyCFunction)pyRecord_setTime, METH_VARARGS,
      "Set record timestamp if TSE==-2.  Record must be locked!"},
     {"scan", (PyCFunction)pyRecord_scan, METH_VARARGS|METH_KEYWORDS,

--- a/devsupApp/src/dbrec.c
+++ b/devsupApp/src/dbrec.c
@@ -324,7 +324,7 @@ static PyMethodDef pyRecord_methods[] = {
      "infos() -> {'name':'value'}\n"
      "Return a dictionary of all infos for this record."},
     {"setSevr", (PyCFunction)pyRecord_setSevr, METH_VARARGS|METH_KEYWORDS,
-     "setSevr(sevr=INVALID_ALARM, stat=COMM_ALARM, amsg=Nome)\n"
+     "setSevr(sevr=INVALID_ALARM, stat=COMM_ALARM, amsg=None)\n"
      "Set alarm new alarm severity/status.  Record must be locked!\n"
      "amsg requires EPICS Base >= 7.0.6."},
     {"setTime", (PyCFunction)pyRecord_setTime, METH_VARARGS,

--- a/devsupApp/src/devsup/test/test_db.py
+++ b/devsupApp/src/devsup/test/test_db.py
@@ -175,7 +175,7 @@ class TestAlarm(IOCHelper):
         rec = getRecord("rec:alarm:msg")
 
         with rec:
-            rec.setSevr(_dbapi.MAJOR_ALARM, _dbapi.HIHI_ALARM, message="Meaningful alarm message")
+            rec.setSevr(_dbapi.MAJOR_ALARM, _dbapi.HIHI_ALARM, amsg="Meaningful alarm message")
             self.assertEqual(rec.NSEV, _dbapi.MAJOR_ALARM)
             self.assertEqual(rec.NSTA, _dbapi.HIHI_ALARM)
             if  _dbapi.epicsver[:4] >= (7, 0, 6, 0):

--- a/devsupApp/src/devsup/test/test_db.py
+++ b/devsupApp/src/devsup/test/test_db.py
@@ -163,3 +163,27 @@ class TestDset(IOCHelper):
         with rec:
             self.assertEqual(rec.VAL, 1)
             self.assertEqual(rec.UDF, 0)
+
+
+class TestAlarm(IOCHelper):
+    db = """
+        record(longin, "rec:alarm:msg") {}
+        record(longin, "rec:alarm:plain") {}
+    """
+
+    def test_set_severity_message(self):
+        rec = getRecord("rec:alarm:msg")
+
+        with rec:
+            rec.setSevr(_dbapi.MAJOR_ALARM, _dbapi.HIHI_ALARM, message="Meaningful alarm message")
+            self.assertEqual(rec.NSEV, _dbapi.MAJOR_ALARM)
+            self.assertEqual(rec.NSTA, _dbapi.HIHI_ALARM)
+            self.assertEqual(rec.NAMSG, "Meaningful alarm message")
+
+    def test_set_severity_without_message(self):
+        rec = getRecord("rec:alarm:plain")
+
+        with rec:
+            rec.setSevr(_dbapi.MAJOR_ALARM, _dbapi.COMM_ALARM)
+            self.assertEqual(rec.NSEV, _dbapi.MAJOR_ALARM)
+            self.assertEqual(rec.NSTA, _dbapi.COMM_ALARM)

--- a/devsupApp/src/devsup/test/test_db.py
+++ b/devsupApp/src/devsup/test/test_db.py
@@ -178,7 +178,8 @@ class TestAlarm(IOCHelper):
             rec.setSevr(_dbapi.MAJOR_ALARM, _dbapi.HIHI_ALARM, message="Meaningful alarm message")
             self.assertEqual(rec.NSEV, _dbapi.MAJOR_ALARM)
             self.assertEqual(rec.NSTA, _dbapi.HIHI_ALARM)
-            self.assertEqual(rec.NAMSG, "Meaningful alarm message")
+            if  _dbapi.epicsver[:4] >= (7, 0, 6, 0):
+                self.assertEqual(rec.NAMSG, "Meaningful alarm message")
 
     def test_set_severity_without_message(self):
         rec = getRecord("rec:alarm:plain")


### PR DESCRIPTION
## Summary
add an optional parameter called `message` to `Record.setSevr()` while preserving all existing functionality

```python
record.setSevr(MINOR_ALARM, HIGH_ALARM, message="Temperature T1 over 100 °C")
```
Existing calls without a message continue to behave as before.

### Details 
- Adds an optional `message` argument to `Record.setSevr()`.
- Uses `recGblSetSevrMsg()` when EPICS Base provides alarm message support.
- Falls back to the existing `recGblSetSevr()` path on older EPICS Base versions.
- Treats `message=None` the same as omitting the message.
- Adds alarm message unit test coverage